### PR TITLE
showFileCounter option not regarded in createProgress

### DIFF
--- a/js/jquery.uploadfile.js
+++ b/js/jquery.uploadfile.js
@@ -161,7 +161,12 @@
             var pd = new createProgressDiv(this, s);
             pd.progressDiv.show();
             pd.progressbar.width('100%');
-            pd.filename.html(obj.fileCounter + s.fileCounterStyle + filename);
+
+            var fileNameStr = "";
+            if(s.showFileCounter) fileNameStr = obj.fileCounter + s.fileCounterStyle + filename;
+            else fileNameStr = filename;
+
+            pd.filename.html(fileNameStr);
             obj.fileCounter++;
             obj.selectedFiles++;
             if(s.showPreview)


### PR DESCRIPTION
I made the change so the file counter will not appear any more if showFileCounter is set to false and you use createProgress to add elements.
