### PR TITLE
Check file extensions with space correct

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -2,16 +2,15 @@
 <head>
 <link href="https://rawgithub.com/hayageek/jquery-upload-file/master/css/uploadfile.css" rel="stylesheet">
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script src="https://rawgithub.com/hayageek/jquery-upload-file/master/js/jquery.uploadfile.min.js"></script>
+<script src="../js/jquery.uploadfile.js"></script>
 </head>
 <body>
 <div id="fileuploader">Upload</div>
 <script>
-$(document).ready(function()
-{
+$(document).ready(function() {
 	$("#fileuploader").uploadFile({
-	url:"http://hayageek.com/examples/jquery/ajax-multiple-file-upload/upload.php",
-	fileName:"myfile"
+		url:"http://hayageek.com/examples/jquery/ajax-multiple-file-upload/upload.php",
+		fileName:"myfile"
 	});
 });
 </script>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -2,7 +2,7 @@
 <head>
 <link href="https://rawgithub.com/hayageek/jquery-upload-file/master/css/uploadfile.css" rel="stylesheet">
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script src="../js/jquery.uploadfile.js"></script>
+<script src="https://rawgithub.com/hayageek/jquery-upload-file/master/js/jquery.uploadfile.min.js"></script>
 </head>
 <body>
 <div id="fileuploader">Upload</div>

--- a/js/jquery.uploadfile.js
+++ b/js/jquery.uploadfile.js
@@ -445,7 +445,7 @@
         }
 
         function isFileTypeAllowed(obj, s, fileName) {
-            var fileExtensions = s.allowedTypes.toLowerCase().split(",");
+            var fileExtensions = s.allowedTypes.toLowerCase().split(/[\s,]+/g);
             var ext = fileName.split('.').pop().toLowerCase();
             if(s.allowedTypes != "*" && jQuery.inArray(ext, fileExtensions) < 0) {
                 return false;


### PR DESCRIPTION
When i list allowed files list to object property, it looks not so good, as it could. Because i have very long list of allowed extensions and this line without spaces looks ugly.

Before:
```javascript
allowedTypes: 'txt,pdf,png,jpg,jpeg,gif,tif,tiff,bmp,xls,xml,xlsx,doc,docx,odt,rtf,ppt,pptx,pps,ppsx,zip,rar'
```
After:

```javascript
allowedTypes: 'txt, pdf, png, jpg, jpeg, gif, tif, tiff, bmp, xls, xml, xlsx, doc, docx, odt, rtf, ppt, pptx, pps, ppsx, zip, rar'
```