### PR TITLE
Set options:multiple to false when maxFileCount is 1

### DIFF
--- a/js/jquery.uploadfile.js
+++ b/js/jquery.uploadfile.js
@@ -104,7 +104,7 @@
         {
             s.dragDrop = false;
         }
-        if(!feature.formdata) {
+        if(!feature.formdata || s.maxFileCount === 1) {
             s.multiple = false;
         }
 


### PR DESCRIPTION
Auto set  ```multiple``` option to false when ```maxFileCount``` is 1.
so there will be 
* auto trigger ```multiDragErrorStr``` instead of ```maxFileCountErrorStr``` for the first attempt , since we actually just allow one file.
* no HTML5 ```multiple``` attribute at input tag, no multiple select.