### PR TITLE
"pd" parameter on downloadCallback does not exist

### DIFF
--- a/js/jquery.uploadfile.js
+++ b/js/jquery.uploadfile.js
@@ -222,7 +222,7 @@
             if(s.showDownload) {
                 pd.download.show();
                 pd.download.click(function () {
-                    if(s.downloadCallback) s.downloadCallback.call(obj, [filename]);
+                    if(s.downloadCallback) s.downloadCallback.call(obj, pd, [filename]);
                 });
             }
             if(s.showDelete)

--- a/js/jquery.uploadfile.js
+++ b/js/jquery.uploadfile.js
@@ -829,7 +829,7 @@
                     if(s.showDownload) {
                         pd.download.show();
                         pd.download.click(function () {
-                            if(s.downloadCallback) s.downloadCallback(data);
+                            if(s.downloadCallback) s.downloadCallback(data,pd);
                         });
                     }
                     form.remove();


### PR DESCRIPTION
Added "pd" parameter, because it didn't work as expected after success event.