### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#[jQuery Upload File](http://hayageek.com/docs/jquery-upload-file.php)
+# [jQuery Upload File](http://hayageek.com/docs/jquery-upload-file.php)
 
-##Overview
+## Overview
 jQuery Upload File plugin provides Multiple file Uploads with progress bar.Works with any server-side platform (Google App Engine, PHP, Python, Ruby on Rails, Java, etc.) that supports standard HTML form file uploads.
 
 ---
 
-#Demo
+# Demo
 http://hayageek.com/docs/jquery-upload-file.php
 
 ---
-#Documentation
+# Documentation
 http://hayageek.com/docs/jquery-upload-file.php#doc
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
