### PR TITLE
Make options for each ajax req immutable

### DIFF
--- a/js/jquery.uploadfile.js
+++ b/js/jquery.uploadfile.js
@@ -365,7 +365,7 @@
             return result;
         }
 		function noserializeAndUploadFiles(s, obj, files) {
-		    var ts = s;
+		    var ts = $.extend({}, s);
                 var fd = new FormData();
                 var fileArray = [];
                 var fileName = s.fileName.replace("[]", "");
@@ -430,7 +430,8 @@
                 }
                 obj.selectedFiles++;
                 obj.existingFileNames.push(files[i].name);
-                var ts = s;
+                // Make object immutable
+                var ts = $.extend({}, s);
                 var fd = new FormData();
                 var fileName = s.fileName.replace("[]", "");
                 fd.append(fileName, files[i]);


### PR DESCRIPTION
I was trying to inject async headers to each request and find out that we are mutating options. So I make cloning options instead of referencing to it.

**Describe issue**: If you upload multiple files simultaneously, for each request only last one will be upload. To reproduce _ajaxFormSubmit_ should be async
![tioquslp83](https://cloud.githubusercontent.com/assets/4943392/25835968/2e8529fc-3440-11e7-85b0-81d71895295a.gif)
